### PR TITLE
Set publishNotReadyAddress in service spec

### DIFF
--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -240,7 +240,7 @@ func newEtcdServiceManifest(svcName, clusterName, clusterIP string, ports []v1.S
 			Ports:     ports,
 			Selector:  labels,
 			ClusterIP: clusterIP,
-			// PublishNotReadyAddresses: publishNotReadyAddresses, // TODO(ckoehn): Activate once TolerateUnreadyEndpointsAnnotation is deprecated.
+			PublishNotReadyAddresses: publishNotReadyAddresses,
 		},
 	}
 	return svc


### PR DESCRIPTION
The old annotation is deprecated

